### PR TITLE
Edit instructions to work for simulated terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ from github.
 
 Manually modifying the files in the `gh-pages` branch is probably the
 wrong thing to do.  Modify the appropriate template or css file on the
-master branch, then run `rake publish`.
+main branch, then run `rake publish`.
 
 ## Lab Format Directives
 
@@ -146,7 +146,7 @@ Example:
     Output:
     git commit
     Waiting for Emacs...
-    [master 569aa96] Using ARGV
+    [main 569aa96] Using ARGV
      1 files changed, 1 insertions(+), 1 deletions(-)
     EOF
 
@@ -185,7 +185,7 @@ Execute sction of a lab.
 Example:
 
     Execute:
-    git checkout master
+    git checkout main
     =checkout
     git status
     =status

--- a/Rakefile
+++ b/Rakefile
@@ -26,14 +26,14 @@ end
 
 desc "Publish the Git Immersion web site."
 task :publish => [:not_dirty, :build, :labs] do
-  sh 'git checkout master'
+  sh 'git checkout main'
   head = `git log --pretty="%h" -n1`.strip
   sh 'git checkout gh-pages'
   cp FileList['git_tutorial/html/*'], '.'
   sh 'git add .'
   sh "git commit -m 'Updated docs to #{head}'"
   sh 'git push'
-  sh 'git checkout master'
+  sh 'git checkout main'
 end
 
 directory "dist"

--- a/docs/lab_01.html
+++ b/docs/lab_01.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_02.html
+++ b/docs/lab_02.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_03.html
+++ b/docs/lab_03.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -123,7 +123,7 @@ git commit -m "First Commit"</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git add hello.js
 $ git commit -m "First Commit"
-[master (root-commit) 284070d] First Commit
+[main (root-commit) 284070d] First Commit
  1 file changed, 1 insertion(+)
  create mode 100644 hello.js
 </pre>

--- a/docs/lab_04.html
+++ b/docs/lab_04.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -105,7 +105,7 @@
 <p>You should see</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git status
-On branch master
+On branch main
 nothing to commit, working tree clean
 </pre>
 <p>The status command reports that there is nothing to commit.  This means that the repository has all the current state of the working directory.  There are no outstanding changes to record.</p>

--- a/docs/lab_05.html
+++ b/docs/lab_05.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -110,7 +110,7 @@
 <p>You should see &#8230;</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git status
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add &lt;file&gt;..." to update what will be committed)
   (use "git checkout -- &lt;file&gt;..." to discard changes in working directory)

--- a/docs/lab_06.html
+++ b/docs/lab_06.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -107,7 +107,7 @@ git status</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git add hello.js
 $ git status
-On branch master
+On branch main
 Changes to be committed:
   (use "git reset HEAD &lt;file&gt;..." to unstage)
 

--- a/docs/lab_07.html
+++ b/docs/lab_07.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_08.html
+++ b/docs/lab_08.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -100,46 +100,16 @@
 </ul>
 <h2>Commit the change</h2>
 <p>Ok, enough about staging.  Let&#8217;s commit what we have staged to the repository.</p>
-<p>When you used <code>git commit</code> previously to commit the initial version of the <code>hello.js</code> file to the repository, you included the <code>-m</code> flag that gave a comment on the command line.  The commit command will allow you to interactively edit a comment for the commit.  Let&#8217;s try that now.</p>
-<p>If you omit the <code>-m</code> flag from the command line, git will pop you into the editor of your choice.  The editor is chosen from the following list (in priority order):</p>
-<ul>
-	<li>GIT_EDITOR environment variable</li>
-	<li>core.editor configuration setting</li>
-	<li><span class="caps">VISUAL</span> environment variable</li>
-	<li><span class="caps">EDITOR</span> environment variable</li>
-</ul>
-<p>I have the <span class="caps">EDITOR</span> variable set to <code>vim</code>.</p>
+<p>Committing is the action of saving the changes to the repository.  It is like taking a snapshot of the changes.  You can always go back to this snapshot later.</p>
 <p>So commit now and check the status.</p>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git commit</pre>
-<p>You should see the following in your editor:</p>
-<h3><b>Output:</b></h3>
-<pre class="sample">|
-# Please enter the commit message for your changes. Lines starting
-# with '#' will be ignored, and an empty message aborts the commit.
-# On branch master
-# Changes to be committed:
-#   (use "git reset HEAD &lt;file&gt;..." to unstage)
-#
-#	modified:   hello.js
-#
-</pre>
-<p>On the first line, enter the comment: &#8220;Using process.argv&#8221;.  Save the file and exit the editor.  You should see &#8230;</p>
-<h3><b>Output:</b></h3>
-<pre class="sample">git commit
-Waiting for Vim...
-[master 569aa96] Using process.argv
- 1 files changed, 1 insertions(+), 1 deletions(-)
-</pre>
-<p>The &#8220;Waiting for Vim&#8230;&#8221; line comes from the <code>vim</code> program which sends the file to a running vim program and waits for the file to be closed.  The rest of the output is the standard commit messages.</p>
-<h2>Check the status</h2>
-<p>Finally let&#8217;s check the status again.</p>
-<h3><b>Execute:</b></h3>
+<pre class="instructions">git commit -m "Using process.argv</pre>
 <pre class="instructions">git status</pre>
+</pre>
 <p>You should see &#8230;</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git status
-On branch master
+On branch main
 nothing to commit, working tree clean
 </pre>
 <p>The working directory is clean and ready for you to continue.</p>

--- a/docs/lab_09.html
+++ b/docs/lab_09.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -126,7 +126,7 @@ console.log(`Hello, ${name}!`);
 <p>You should see &#8230;</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git status
-On branch master
+On branch main
 Changes to be committed:
   (use "git reset HEAD &lt;file&gt;..." to unstage)
 
@@ -149,10 +149,10 @@ git status</pre>
 <p>You should see &#8230;</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git commit -m "Added a default value"
-[master 20a6c79] Added a default value
+[main 20a6c79] Added a default value
  1 file changed, 3 insertions(+), 1 deletion(-)
 $ git status
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add &lt;file&gt;..." to update what will be committed)
   (use "git checkout -- &lt;file&gt;..." to discard changes in working directory)
@@ -172,7 +172,7 @@ git status</pre>
 <p>You should see &#8230;</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git status
-On branch master
+On branch main
 Changes to be committed:
   (use "git reset HEAD &lt;file&gt;..." to unstage)
 

--- a/docs/lab_10.html
+++ b/docs/lab_10.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -159,7 +159,7 @@ git log --pretty=oneline --all</pre>
 <p>It looks like this:</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git log --pretty=format:'%h %ad | %s%d [%an]' --graph --date=short
-* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; master) [Halle Bot]
+* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; main) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>

--- a/docs/lab_11.html
+++ b/docs/lab_11.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -100,7 +100,8 @@
 </ul>
 <h2>Common Aliases</h2>
 <p><code>git status</code>, <code>git add</code>, <code>git commit</code>, and <code>git checkout</code> are such common commands that it is useful to have abbreviations for them.</p>
-<p>Add the following to the .gitconfig file in your $<span class="caps">HOME</span> directory.</p>
+<p>Add the following to the .gitconfig file in your $<span class="caps">HOME</span> directory.</p> 
+<p>Try using the command: <code>git config --global alias.[alias-name] [command]</code> to add the alias to your .gitconfig file. Replace the values that are in the <code>[]</code> brackets with the actual alias name and comand</p>
 <h3 class="file-heading"><em>.gitconfig</em></h3>
 <pre class="file">[alias]
   co = checkout

--- a/docs/lab_12.html
+++ b/docs/lab_12.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -105,7 +105,7 @@
 <p class="note"><strong>Note:</strong> You did remember to define <code>hist</code> in your <code>.gitconfig</code> file, right?  If not, review the lab on aliases.</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist
-* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; master) [Halle Bot]
+* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; main) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
@@ -135,22 +135,22 @@ console.log("Hello, World");
 </pre>
 <p>The output of the <code>checkout</code> command explains the situation pretty well.  Older versions of git will complain about not being on a local branch.  In any case, don&#8217;t worry about that for now.</p>
 <p>Notice the contents of the hello.js file are the original contents.</p>
-<h2>Return the latest version in the master branch</h2>
+<h2>Return the latest version in the main branch</h2>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git checkout master
+<pre class="instructions">git checkout main
 cat hello.js</pre>
 <p>You should see &#8230;</p>
 <h3><b>Output:</b></h3>
-<pre class="sample">$ git checkout master
+<pre class="sample">$ git checkout main
 Previous HEAD position was 284070d First Commit
-Switched to branch 'master'
+Switched to branch 'main'
 $ cat hello.js
 // Default is "World"
 const name = process.argv[2] || "World";
 
 console.log(`Hello, ${name}!`);
 </pre>
-<p>&#8216;master&#8217; is the name of the default branch.  By checking out a branch by name, you go to the latest version of that branch.</p>
+<p>&#8216;main&#8217; is the name of the default branch.  By checking out a branch by name, you go to the latest version of that branch.</p>
         <nav class="foot-navigation">
       <a href="lab_11.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_13.html
+++ b/docs/lab_13.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -156,14 +156,14 @@ v1-beta
 <h2>Viewing Tags in the Logs</h2>
 <p>You can also check for tags in the log.</p>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git hist master --all</pre>
+<pre class="instructions">git hist main --all</pre>
 <h3><b>Output:</b></h3>
-<pre class="sample">$ git hist master --all
-* 59992ce 2019-06-27 | Added a comment (tag: v1, master) [Halle Bot]
+<pre class="sample">$ git hist main --all
+* 59992ce 2019-06-27 | Added a comment (tag: v1, main) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value (HEAD, tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<p>You can see both tags (<code>v1</code> and <code>v1-beta</code>) listed in the log output, along with the branch name (<code>master</code>).  Also <code>HEAD</code> shows you the currently checked out commit (which is <code>v1-beta</code> at the moment).</p>
+<p>You can see both tags (<code>v1</code> and <code>v1-beta</code>) listed in the log output, along with the branch name (<code>main</code>).  Also <code>HEAD</code> shows you the currently checked out commit (which is <code>v1-beta</code> at the moment).</p>
         <nav class="foot-navigation">
       <a href="lab_12.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_14.html
+++ b/docs/lab_14.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -98,10 +98,10 @@
 <ul>
 	<li>Learn how to revert changes in the working directory</li>
 </ul>
-<h2>Checkout Master</h2>
-<p>Make sure you are on the latest commit in master before proceeding.</p>
+<h2>Checkout Main</h2>
+<p>Make sure you are on the latest commit in main before proceeding.</p>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git checkout master</pre>
+<pre class="instructions">git checkout main</pre>
 <h2>Change hello.js</h2>
 <p>Sometimes you have modified a file in your local working directory and you wish to just revert to what has already been committed.  The checkout command will handle that.</p>
 <p>Change hello.js to have a bad comment.</p>
@@ -117,7 +117,7 @@ console.log(`Hello, ${name}!`);
 <pre class="instructions">git status</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git status
-On branch master
+On branch main
 Changes not staged for commit:
   (use "git add &lt;file&gt;..." to update what will be committed)
   (use "git checkout -- &lt;file&gt;..." to discard changes in working directory)
@@ -136,7 +136,7 @@ cat hello.js</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git checkout hello.js
 $ git status
-On branch master
+On branch main
 nothing to commit, working tree clean
 $ cat hello.js
 // Default is "World"

--- a/docs/lab_15.html
+++ b/docs/lab_15.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -115,7 +115,7 @@ console.log(`Hello, ${name}!`);
 <pre class="instructions">git status</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git status
-On branch master
+On branch main
 Changes to be committed:
   (use "git reset HEAD &lt;file&gt;..." to unstage)
 
@@ -140,7 +140,7 @@ M	hello.js
 git status</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git status
-On branch master
+On branch main
 nothing to commit, working tree clean
 </pre>
 <p>And our working directory is clean once again.</p>

--- a/docs/lab_16.html
+++ b/docs/lab_16.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -119,7 +119,7 @@ git commit -m "Oops, we didn't want this commit"</pre>
 <p>This will pop you into the editor.  You can edit the default commit message or leave it as is.  Save and close the file. You should see &#8230;</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git revert HEAD --no-edit
-[master 654f128] Revert "Oops, we didn't want this commit"
+[main 654f128] Revert "Oops, we didn't want this commit"
  Date: Thu Jun 27 14:45:18 2019 -0500
  1 file changed, 2 insertions(+), 2 deletions(-)
 </pre>
@@ -131,7 +131,7 @@ git commit -m "Oops, we didn't want this commit"</pre>
 <pre class="instructions">git hist</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist
-* 654f128 2019-06-27 | Revert "Oops, we didn't want this commit" (HEAD -&gt; master) [Halle Bot]
+* 654f128 2019-06-27 | Revert "Oops, we didn't want this commit" (HEAD -&gt; main) [Halle Bot]
 * 982fd79 2019-06-27 | Oops, we didn't want this commit [Halle Bot]
 * 59992ce 2019-06-27 | Added a comment (tag: v1) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]

--- a/docs/lab_17.html
+++ b/docs/lab_17.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -114,7 +114,7 @@
 <pre class="instructions">git hist</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist
-* 654f128 2019-06-27 | Revert "Oops, we didn't want this commit" (HEAD -&gt; master) [Halle Bot]
+* 654f128 2019-06-27 | Revert "Oops, we didn't want this commit" (HEAD -&gt; main) [Halle Bot]
 * 982fd79 2019-06-27 | Oops, we didn't want this commit [Halle Bot]
 * 59992ce 2019-06-27 | Added a comment (tag: v1) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
@@ -134,11 +134,11 @@ git hist</pre>
 <pre class="sample">$ git reset --hard v1
 HEAD is now at 59992ce Added a comment
 $ git hist
-* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; master, tag: v1) [Halle Bot]
+* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; main, tag: v1) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<p>Our master branch now points to the v1 commit and the Oops commit and the Revert Oops commit are no longer in the branch.  The <code>--hard</code> parameter indicates that the working directory should be updated to be consistent with the new branch head.</p>
+<p>Our main branch now points to the v1 commit and the Oops commit and the Revert Oops commit are no longer in the branch.  The <code>--hard</code> parameter indicates that the working directory should be updated to be consistent with the new branch head.</p>
 <h2>Nothing is Ever Lost</h2>
 <p>But what happened to the bad commits?  It turns out that the commits are still in the repository.  In fact, we can still reference them.  Remember that at the beginning of this lab we tagged the reverting commit with the tag &#8220;oops&#8221;.  Let&#8217;s look at <em>all</em> the commits.</p>
 <h3><b>Execute:</b></h3>
@@ -147,11 +147,11 @@ $ git hist
 <pre class="sample">$ git hist --all
 * 654f128 2019-06-27 | Revert "Oops, we didn't want this commit" (tag: oops) [Halle Bot]
 * 982fd79 2019-06-27 | Oops, we didn't want this commit [Halle Bot]
-* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; master, tag: v1) [Halle Bot]
+* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; main, tag: v1) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<p>Here we see that the bad commits haven&#8217;t disappeared.  They are still in the repository.  It&#8217;s just that they are no longer listed in the master branch.  If we hadn&#8217;t tagged them, they would still be in the repository, but there would be no way to reference them other than using their hash names.  Commits that are unreferenced remain in the repository until the system runs the garbage collection software.</p>
+<p>Here we see that the bad commits haven&#8217;t disappeared.  They are still in the repository.  It&#8217;s just that they are no longer listed in the main branch.  If we hadn&#8217;t tagged them, they would still be in the repository, but there would be no way to reference them other than using their hash names.  Commits that are unreferenced remain in the repository until the system runs the garbage collection software.</p>
 <h2>Dangers of Reset</h2>
 <p>Resets on local branches are generally safe.  Any &#8220;accidents&#8221; can usually be recovered from by just resetting again with the desired commit.</p>
 <p>However, if the branch is shared on remote repositories, resetting can confuse other users sharing the branch.</p>

--- a/docs/lab_18.html
+++ b/docs/lab_18.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -107,7 +107,7 @@ git hist --all</pre>
 <pre class="sample">$ git tag -d oops
 Deleted tag 'oops' (was 654f128)
 $ git hist --all
-* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; master, tag: v1) [Halle Bot]
+* 59992ce 2019-06-27 | Added a comment (HEAD -&gt; main, tag: v1) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>

--- a/docs/lab_19.html
+++ b/docs/lab_19.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -127,7 +127,7 @@ git commit --amend -m "Add an author/email comment"</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git add hello.js
 $ git commit --amend -m "Add an author/email comment"
-[master 4535421] Add an author/email comment
+[main 4535421] Add an author/email comment
  Date: Thu Jun 27 14:45:19 2019 -0500
  1 file changed, 3 insertions(+), 2 deletions(-)
 </pre>
@@ -136,7 +136,7 @@ $ git commit --amend -m "Add an author/email comment"
 <pre class="instructions">git hist</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist
-* 4535421 2019-06-27 | Add an author/email comment (HEAD -&gt; master) [Halle Bot]
+* 4535421 2019-06-27 | Add an author/email comment (HEAD -&gt; main) [Halle Bot]
 * 59992ce 2019-06-27 | Added a comment (tag: v1) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]

--- a/docs/lab_20.html
+++ b/docs/lab_20.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -108,7 +108,7 @@ git status</pre>
 <pre class="sample">$ mkdir lib
 $ git mv hello.js lib
 $ git status
-On branch master
+On branch main
 Changes to be committed:
   (use "git reset HEAD &lt;file&gt;..." to unstage)
 

--- a/docs/lab_21.html
+++ b/docs/lab_21.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_21.html
+++ b/docs/lab_21.html
@@ -100,7 +100,7 @@
 </ul>
 <h2>Now add a package.json</h2>
 <p>This lab assumes you have installed <strong>node</strong>. Please do that before continuing.</p>
-<p>Let&#8217;s add a package.json to our repository.  The following one will do nicely.</p>
+<p>Let&#8217;s add a package.json to the hello directory.  The following one will do nicely.</p>
 <h3 class="file-heading"><em>package.json</em></h3>
 <pre class="file">{
   "name": "greeter",
@@ -116,7 +116,10 @@
 <pre class="instructions">git add package.json
 git commit -m "Added a package.json."</pre>
 <p>You should be able to use npm to run your hello program now.</p>
+<p>In order to run our program we will exit the simulation terminal. Close out the simulation, run the program, and then go back to the simulation</p>
 <h3><b>Execute:</b></h3>
+<pre >- Press ctrl and C simultaneously to close the simulation</pre>
+<p class="instructions">cd hello</p>
 <pre class="instructions">npm start</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ npm start
@@ -126,6 +129,9 @@ git commit -m "Added a package.json."</pre>
 
 Hello, World!
 </pre>
+<h3><b>Go back to the terminal simulation</b></h3>
+<pre class="instructions">cd ..</pre>
+<pre class="instructions">npm start</pre>
         <nav class="foot-navigation">
       <a href="lab_20.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_22.html
+++ b/docs/lab_22.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -98,7 +98,7 @@
 <ul>
 	<li>Learn how to create a local branch in a repository</li>
 </ul>
-<p>It&#8217;s time to do a major rewrite of the hello world functionality. Since this might take awhile, you&#8217;ll want to put these changes into a separate branch to isolate them from changes in master.</p>
+<p>It&#8217;s time to do a major rewrite of the hello world functionality. Since this might take awhile, you&#8217;ll want to put these changes into a separate branch to isolate them from changes in main.</p>
 <h2>Create a Branch</h2>
 <p>Let&#8217;s call our new branch &#8216;greet&#8217;.</p>
 <h3><b>Execute:</b></h3>

--- a/docs/lab_23.html
+++ b/docs/lab_23.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -106,21 +106,21 @@
 * f52644d 2019-06-27 | Updated package (HEAD -&gt; greet) [Halle Bot]
 * 455c54f 2019-06-27 | Hello uses Greeter [Halle Bot]
 * 4fb8bde 2019-06-27 | Added greeter class [Halle Bot]
-* 2b04803 2019-06-27 | Added a package.json. (master) [Halle Bot]
+* 2b04803 2019-06-27 | Added a package.json. (main) [Halle Bot]
 * b65b430 2019-06-27 | Moved hello.js to lib [Halle Bot]
 * 4535421 2019-06-27 | Add an author/email comment [Halle Bot]
 * 59992ce 2019-06-27 | Added a comment (tag: v1) [Halle Bot]
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<h2>Switch to the Master Branch</h2>
+<h2>Switch to the Main Branch</h2>
 <p>Just use the <code>git checkout</code> command to switch between branches.</p>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git checkout master
+<pre class="instructions">git checkout main
 cat lib/hello.js</pre>
 <h3><b>Output:</b></h3>
-<pre class="sample">$ git checkout master
-Switched to branch 'master'
+<pre class="sample">$ git checkout main
+Switched to branch 'main'
 $ cat lib/hello.js
 // Default is World
 // Author: Jim Weirich (jim@somewhere.com)
@@ -128,7 +128,7 @@ const name = process.argv[2] || "World"
 
 console.log(`Hello, ${name}!`);
 </pre>
-<p>You are now on the master branch.  You can tell because the hello.js file doesn&#8217;t use the <code>Greeter</code> class.</p>
+<p>You are now on the main branch.  You can tell because the hello.js file doesn&#8217;t use the <code>Greeter</code> class.</p>
 <h2>Switch Back to the Greet Branch.</h2>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git checkout greet

--- a/docs/lab_24.html
+++ b/docs/lab_24.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -93,20 +93,20 @@
       </div>
 
       <div id="content" tabindex="-1">
-        <h1 class="lab_title"><em>lab 24</em>  Changes in Master</h1>
+        <h1 class="lab_title"><em>lab 24</em>  Changes in Main</h1>
 <h2>Goals</h2>
 <ul>
 	<li>Learning how to deal with multiple branches with different (and possibly conflicting) changes.</li>
 </ul>
-<p>While you were changing the greet branch, someone else decided to update the master branch.  They added a <span class="caps">README</span>.</p>
-<h2>Switch to the master branch.</h2>
+<p>While you were changing the greet branch, someone else decided to update the main branch.  They added a <span class="caps">README</span>.</p>
+<h2>Switch to the main branch.</h2>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git checkout master</pre>
+<pre class="instructions">git checkout main</pre>
 <h2>Create the <span class="caps">README</span>.</h2>
 <h3 class="file-heading"><em><span class="caps">README</span></em></h3>
 <pre class="file">This is the Hello World example from the git tutorial.
 </pre>
-<h2>Commit the <span class="caps">README</span> to master.</h2>
+<h2>Commit the <span class="caps">README</span> to main.</h2>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git add README
 git commit -m "Added README"</pre>

--- a/docs/lab_24.html
+++ b/docs/lab_24.html
@@ -108,7 +108,7 @@
 </pre>
 <h2>Commit the <span class="caps">README</span> to main.</h2>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git add README
+<pre class="instructions">git add lib/README
 git commit -m "Added README"</pre>
         <nav class="foot-navigation">
       <a href="lab_23.html">

--- a/docs/lab_25.html
+++ b/docs/lab_25.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -104,7 +104,7 @@
 <pre class="instructions">git hist --all</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist --all
-* 3aa3064 2019-06-27 | Added README (HEAD -&gt; master) [Halle Bot]
+* 3aa3064 2019-06-27 | Added README (HEAD -&gt; main) [Halle Bot]
 | * f52644d 2019-06-27 | Updated package (greet) [Halle Bot]
 | * 455c54f 2019-06-27 | Hello uses Greeter [Halle Bot]
 | * 4fb8bde 2019-06-27 | Added greeter class [Halle Bot]
@@ -116,7 +116,7 @@
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<p>Here is our first chance to see the <code>--graph</code> option on <code>git hist</code> in action. Adding the <code>--graph</code> option to <code>git log</code> causes it to draw the commit tree using simple <span class="caps">ASCII</span> characters.  We can see both branches (greet and master), and that the master branch is the current <span class="caps">HEAD</span>. The common ancestor to both branches is the &#8220;Added a Rakefile&#8221; branch.</p>
+<p>Here is our first chance to see the <code>--graph</code> option on <code>git hist</code> in action. Adding the <code>--graph</code> option to <code>git log</code> causes it to draw the commit tree using simple <span class="caps">ASCII</span> characters.  We can see both branches (greet and main), and that the main branch is the current <span class="caps">HEAD</span>. The common ancestor to both branches is the &#8220;Added a Rakefile&#8221; branch.</p>
 <p>The <code>--all</code> flag makes sure that we see all the branches.  The default is to show only the current branch.</p>
         <nav class="foot-navigation">
       <a href="lab_24.html">

--- a/docs/lab_26.html
+++ b/docs/lab_26.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -99,23 +99,23 @@
 	<li>Learn how to merge two diverging branches to bring the changes back into a single branch.</li>
 </ul>
 <h2>Merge the branches</h2>
-<p>Merging brings the changes in two branches together.  Let&#8217;s go back to the greet branch and merge master onto greet.</p>
+<p>Merging brings the changes in two branches together.  Let&#8217;s go back to the greet branch and merge main onto greet.</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git checkout greet
-git merge master
+git merge main
 git hist --all</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git checkout greet
 Switched to branch 'greet'
-$ git merge master
+$ git merge main
 Merge made by the 'recursive' strategy.
  README | 1 +
  1 file changed, 1 insertion(+)
  create mode 100644 README
 $ git hist --all
-*   8c53c97 2019-06-27 | Merge branch 'master' into greet (HEAD -&gt; greet) [Halle Bot]
+*   8c53c97 2019-06-27 | Merge branch 'main' into greet (HEAD -&gt; greet) [Halle Bot]
 |\  
-| * 3aa3064 2019-06-27 | Added README (master) [Halle Bot]
+| * 3aa3064 2019-06-27 | Added README (main) [Halle Bot]
 * | f52644d 2019-06-27 | Updated package [Halle Bot]
 * | 455c54f 2019-06-27 | Hello uses Greeter [Halle Bot]
 * | 4fb8bde 2019-06-27 | Added greeter class [Halle Bot]
@@ -127,10 +127,10 @@ $ git hist --all
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<p>By merging master into your greet branch periodically, you can pick up any changes to master and keep your changes in greet compatible with changes in the mainline.</p>
+<p>By merging main into your greet branch periodically, you can pick up any changes to main and keep your changes in greet compatible with changes in the mainline.</p>
 <p>However, it does produce ugly commit graphs. Later we will look at the option of rebasing rather than merging.</p>
 <h2>Up Next</h2>
-<p>But first, what if the changes in master conflict with the changes in greet?</p>
+<p>But first, what if the changes in main conflict with the changes in greet?</p>
         <nav class="foot-navigation">
       <a href="lab_25.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_27.html
+++ b/docs/lab_27.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -96,12 +96,12 @@
         <h1 class="lab_title"><em>lab 27</em>  Creating a Conflict</h1>
 <h2>Goals</h2>
 <ul>
-	<li>Create a conflicting change in the master branch.</li>
+	<li>Create a conflicting change in the main branch.</li>
 </ul>
-<h2>Switch back to master and create a conflict</h2>
-<p>Switch back to the master branch and make this change:</p>
+<h2>Switch back to main and create a conflict</h2>
+<p>Switch back to the main branch and make this change:</p>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git checkout master</pre>
+<pre class="instructions">git checkout main</pre>
 <h3 class="file-heading"><em>lib/hello.js</em></h3>
 <pre class="file">const rl = require('readline').createInterface({
   input: process.stdin,
@@ -121,12 +121,12 @@ git commit -m "Made interactive"</pre>
 <pre class="instructions">git hist --all</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist --all
-*   8c53c97 2019-06-27 | Merge branch 'master' into greet (greet) [Halle Bot]
+*   8c53c97 2019-06-27 | Merge branch 'main' into greet (greet) [Halle Bot]
 |\  
 * | f52644d 2019-06-27 | Updated package [Halle Bot]
 * | 455c54f 2019-06-27 | Hello uses Greeter [Halle Bot]
 * | 4fb8bde 2019-06-27 | Added greeter class [Halle Bot]
-| | * 3c663d0 2019-06-27 | Made interactive (HEAD -&gt; master) [Halle Bot]
+| | * 3c663d0 2019-06-27 | Made interactive (HEAD -&gt; main) [Halle Bot]
 | |/  
 | * 3aa3064 2019-06-27 | Added README [Halle Bot]
 |/  
@@ -137,9 +137,9 @@ git commit -m "Made interactive"</pre>
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<p>Master at commit &#8220;Added <span class="caps">README</span>&#8221; has been merged to the greet branch, but there is now an additional commit on master that has not been merged back to greet.</p>
+<p>Main at commit &#8220;Added <span class="caps">README</span>&#8221; has been merged to the greet branch, but there is now an additional commit on main that has not been merged back to greet.</p>
 <h2>Up Next</h2>
-<p>The latest change in master conflicts with some existing changes in greet.  Next we will resolve those changes.</p>
+<p>The latest change in main conflicts with some existing changes in greet.  Next we will resolve those changes.</p>
         <nav class="foot-navigation">
       <a href="lab_26.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_28.html
+++ b/docs/lab_28.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -98,15 +98,15 @@
 <ul>
 	<li>Learn how to handle conflicts during a merge</li>
 </ul>
-<h2>Merge master to greet</h2>
-<p>Now go back to the greet branch and try to merge the new master.</p>
+<h2>Merge main to greet</h2>
+<p>Now go back to the greet branch and try to merge the new main.</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git checkout greet
-git merge master</pre>
+git merge main</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git checkout greet
 Switched to branch 'greet'
-$ git merge master
+$ git merge main
 Auto-merging lib/hello.js
 CONFLICT (content): Merge conflict in lib/hello.js
 Automatic merge failed; fix conflicts and then commit the result.
@@ -132,10 +132,10 @@ rl.question(`What's your name`, (myName) =&gt; {
   console.log(`Hello ${myName}!`)
   rl.close();
 });
-&gt;&gt;&gt;&gt;&gt;&gt;&gt; master
+&gt;&gt;&gt;&gt;&gt;&gt;&gt; main
 </pre>
 <p><!-- ^^^^^^^^^  DO NOT FIX THIS MERGE CONFLICT ^^^^^^^^^ --><br />
-p. The first section is the version on the head of the current branch (greet).  The second section is the version on the master branch.</p>
+p. The first section is the version on the head of the current branch (greet).  The second section is the version on the main branch.</p>
 <h2>Fix the Conflict</h2>
 <p>You need to manually resolve the conflict.  Modify <code>lib/hello.js</code> to be the following.</p>
 <h3 class="file-heading"><em>lib/hello.js</em></h3>
@@ -156,11 +156,11 @@ rl.question(`What's your name`, (myName) =&gt; {
 <h2>Commit the Conflict Resolution</h2>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git add lib/hello.js
-git commit -m "Merged master fixed conflict."</pre>
+git commit -m "Merged main fixed conflict."</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git add lib/hello.js
-$ git commit -m "Merged master fixed conflict."
-[greet ca11819] Merged master fixed conflict.
+$ git commit -m "Merged main fixed conflict."
+[greet ca11819] Merged main fixed conflict.
 </pre>
 <h2>Advanced Merging</h2>
 <p>git doesn&#8217;t provide any graphical merge tools, but it will gladly work with any third party merge tool you wish to use.  See <a href="http://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#External-Merge-and-Diff-Tools">http://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#External-Merge-and-Diff-Tools</a> for a description of using the Perforce merge tool with git.</p>

--- a/docs/lab_29.html
+++ b/docs/lab_29.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_30.html
+++ b/docs/lab_30.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -99,8 +99,8 @@
 	<li>Reset the greet branch to the point before the first merge.</li>
 </ul>
 <h2>Reset the greet branch</h2>
-<p>Let&#8217;s go back in time on the greet branch to the point <em>before</em> we merged master onto it.  We can <strong>reset</strong> a branch to any commit we want. Essentially this is modifying the branch pointer to point to anywhere in the commit tree.</p>
-<p>In this case we want to back greet up to the point prior to the merge with master.  We need to find the last commit before the merge.</p>
+<p>Let&#8217;s go back in time on the greet branch to the point <em>before</em> we merged main onto it.  We can <strong>reset</strong> a branch to any commit we want. Essentially this is modifying the branch pointer to point to anywhere in the commit tree.</p>
+<p>In this case we want to back greet up to the point prior to the merge with main.  We need to find the last commit before the merge.</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git checkout greet
 git hist</pre>
@@ -108,10 +108,10 @@ git hist</pre>
 <pre class="sample">$ git checkout greet
 Already on 'greet'
 $ git hist
-*   ca11819 2019-06-27 | Merged master fixed conflict. (HEAD -&gt; greet) [Halle Bot]
+*   ca11819 2019-06-27 | Merged main fixed conflict. (HEAD -&gt; greet) [Halle Bot]
 |\  
-| * 3c663d0 2019-06-27 | Made interactive (master) [Halle Bot]
-* |   8c53c97 2019-06-27 | Merge branch 'master' into greet [Halle Bot]
+| * 3c663d0 2019-06-27 | Made interactive (main) [Halle Bot]
+* |   8c53c97 2019-06-27 | Merge branch 'main' into greet [Halle Bot]
 |\ \  
 | |/  
 | * 3aa3064 2019-06-27 | Added README [Halle Bot]
@@ -139,7 +139,7 @@ HEAD is now at f52644d Updated package
 <pre class="instructions">git hist --all</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist --all
-* 3c663d0 2019-06-27 | Made interactive (master) [Halle Bot]
+* 3c663d0 2019-06-27 | Made interactive (main) [Halle Bot]
 * 3aa3064 2019-06-27 | Added README [Halle Bot]
 | * f52644d 2019-06-27 | Updated package (HEAD -&gt; greet) [Halle Bot]
 | * 455c54f 2019-06-27 | Hello uses Greeter [Halle Bot]

--- a/docs/lab_31.html
+++ b/docs/lab_31.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -93,19 +93,19 @@
       </div>
 
       <div id="content" tabindex="-1">
-        <h1 class="lab_title"><em>lab 31</em>  Resetting the Master Branch</h1>
+        <h1 class="lab_title"><em>lab 31</em>  Resetting the Main Branch</h1>
 <h2>Goals</h2>
 <ul>
-	<li>Reset the master branch to the point before the conflicting commit.</li>
+	<li>Reset the main branch to the point before the conflicting commit.</li>
 </ul>
-<h2>Reset the master branch</h2>
-<p>When we added the interactive mode to the master branch, we made a change that conflicted with changes in the greet branch. Let&#8217;s rewind the master branch to a point before the conflicting change.  This allows us to demonstrate the rebase command without worrying about conflicts.</p>
+<h2>Reset the main branch</h2>
+<p>When we added the interactive mode to the main branch, we made a change that conflicted with changes in the greet branch. Let&#8217;s rewind the main branch to a point before the conflicting change.  This allows us to demonstrate the rebase command without worrying about conflicts.</p>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git checkout master
+<pre class="instructions">git checkout main
 git hist</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist
-* 3c663d0 2019-06-27 | Made interactive (HEAD -&gt; master) [Halle Bot]
+* 3c663d0 2019-06-27 | Made interactive (HEAD -&gt; main) [Halle Bot]
 * 3aa3064 2019-06-27 | Added README [Halle Bot]
 * 2b04803 2019-06-27 | Added a package.json. [Halle Bot]
 * b65b430 2019-06-27 | Moved hello.js to lib [Halle Bot]
@@ -114,14 +114,14 @@ git hist</pre>
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<p>The &#8216;Added <span class="caps">README</span>&#8217; commit is the one directly before the conflicting interactive mode.  We will reset the master branch to &#8216;Added <span class="caps">README</span>&#8217; branch.</p>
+<p>The &#8216;Added <span class="caps">README</span>&#8217; commit is the one directly before the conflicting interactive mode.  We will reset the main branch to &#8216;Added <span class="caps">README</span>&#8217; branch.</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git reset --hard &lt;hash&gt;
 git hist --all</pre>
 <p>Review the log.  It should look like the repository has been wound back in time to the point before we merged anything.</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist --all
-* 3aa3064 2019-06-27 | Added README (HEAD -&gt; master) [Halle Bot]
+* 3aa3064 2019-06-27 | Added README (HEAD -&gt; main) [Halle Bot]
 | * f52644d 2019-06-27 | Updated package (greet) [Halle Bot]
 | * 455c54f 2019-06-27 | Hello uses Greeter [Halle Bot]
 | * 4fb8bde 2019-06-27 | Added greeter class [Halle Bot]

--- a/docs/lab_32.html
+++ b/docs/lab_32.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -98,17 +98,17 @@
 <ul>
 	<li>Use the rebase command rather than the merge command.</li>
 </ul>
-<p>Ok, we are back in time before the first merge and we want to get the changes in master into our greet branch.</p>
-<p>This time we will use the rebase command instead of the merge command to bring in the changes from the master branch.</p>
+<p>Ok, we are back in time before the first merge and we want to get the changes in main into our greet branch.</p>
+<p>This time we will use the rebase command instead of the merge command to bring in the changes from the main branch.</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git checkout greet
-git rebase master
+git rebase main
 git hist</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ go greet
 Switched to branch 'greet'
 $
-$ git rebase master
+$ git rebase main
 First, rewinding head to replay your work on top of it...
 Applying: added Greeter class
 Applying: hello uses Greeter
@@ -118,7 +118,7 @@ $ git hist
 * c6d9ed3 2019-06-27 | Updated package (HEAD -&gt; greet) [Halle Bot]
 * 56af19d 2019-06-27 | Hello uses Greeter [Halle Bot]
 * 1e7679d 2019-06-27 | Added greeter class [Halle Bot]
-* 3aa3064 2019-06-27 | Added README (master) [Halle Bot]
+* 3aa3064 2019-06-27 | Added README (main) [Halle Bot]
 * 2b04803 2019-06-27 | Added a package.json. [Halle Bot]
 * b65b430 2019-06-27 | Moved hello.js to lib [Halle Bot]
 * 4535421 2019-06-27 | Add an author/email comment [Halle Bot]
@@ -127,7 +127,7 @@ $ git hist
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
 <h2>Merge VS Rebase</h2>
-<p>The final result of the rebase is very similar to the merge.  The greet branch now contains all of its changes, as well as all the changes from the master branch.  However, the commit tree is quite different.  The commit tree for the greet branch has been rewritten so that the master branch is a part of the commit history.  This leaves the chain of commits linear and much easier to read.</p>
+<p>The final result of the rebase is very similar to the merge.  The greet branch now contains all of its changes, as well as all the changes from the main branch.  However, the commit tree is quite different.  The commit tree for the greet branch has been rewritten so that the main branch is a part of the commit history.  This leaves the chain of commits linear and much easier to read.</p>
 <h2>When to Rebase, When to Merge?</h2>
 <p>Don&#8217;t use rebase &#8230;</p>
 <ol>

--- a/docs/lab_33.html
+++ b/docs/lab_33.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -93,18 +93,18 @@
       </div>
 
       <div id="content" tabindex="-1">
-        <h1 class="lab_title"><em>lab 33</em>  Merging Back to Master</h1>
+        <h1 class="lab_title"><em>lab 33</em>  Merging Back to Main</h1>
 <h2>Goals</h2>
 <ul>
-	<li>We&#8217;ve kept our greet branch up to date with master (via rebase), now let&#8217;s merge the greet changes back into the master branch.</li>
+	<li>We&#8217;ve kept our greet branch up to date with main (via rebase), now let&#8217;s merge the greet changes back into the main branch.</li>
 </ul>
-<h2>Merge greet into master</h2>
+<h2>Merge greet into main</h2>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git checkout master
+<pre class="instructions">git checkout main
 git merge greet</pre>
 <h3><b>Output:</b></h3>
-<pre class="sample">$ git checkout master
-Switched to branch 'master'
+<pre class="sample">$ git checkout main
+Switched to branch 'main'
 $
 $ git merge greet
 Updating 3aa3064..c6d9ed3
@@ -115,14 +115,14 @@ Fast-forward
  3 files changed, 16 insertions(+), 3 deletions(-)
  create mode 100644 lib/greeter.js
 </pre>
-<p>Because the head of master is a direct ancestor of the head of the greet branch, git is able to do a fast-forward merge.  When fast-forwarding, the branch pointer is simply moved forward to point to the same commit as the greeter branch.</p>
+<p>Because the head of main is a direct ancestor of the head of the greet branch, git is able to do a fast-forward merge.  When fast-forwarding, the branch pointer is simply moved forward to point to the same commit as the greeter branch.</p>
 <p>There will never be conflicts in a fast-forward merge.</p>
 <h2>Review the logs</h2>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git hist</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist
-* c6d9ed3 2019-06-27 | Updated package (HEAD -&gt; master, greet) [Halle Bot]
+* c6d9ed3 2019-06-27 | Updated package (HEAD -&gt; main, greet) [Halle Bot]
 * 56af19d 2019-06-27 | Hello uses Greeter [Halle Bot]
 * 1e7679d 2019-06-27 | Added greeter class [Halle Bot]
 * 3aa3064 2019-06-27 | Added README [Halle Bot]
@@ -133,7 +133,7 @@ Fast-forward
 * 20a6c79 2019-06-27 | Added a default value (tag: v1-beta) [Halle Bot]
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
-<p>The greet and master branches are now identical.</p>
+<p>The greet and main branches are now identical.</p>
         <nav class="foot-navigation">
       <a href="lab_32.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_34.html
+++ b/docs/lab_34.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_35.html
+++ b/docs/lab_35.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_36.html
+++ b/docs/lab_36.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -116,7 +116,7 @@ package.json
 <pre class="instructions">git hist --all</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git hist --all
-* c6d9ed3 2019-06-27 | Updated package (HEAD -&gt; master, origin/master, origin/greet, origin/HEAD) [Halle Bot]
+* c6d9ed3 2019-06-27 | Updated package (HEAD -&gt; main, origin/main, origin/greet, origin/HEAD) [Halle Bot]
 * 56af19d 2019-06-27 | Hello uses Greeter [Halle Bot]
 * 1e7679d 2019-06-27 | Added greeter class [Halle Bot]
 * 3aa3064 2019-06-27 | Added README [Halle Bot]
@@ -129,7 +129,7 @@ package.json
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
 <p>You should now see a list of the all the commits in the new repository, and it should (more or less) match the history of commits in the original repository.  The only difference should be in the names of the branches.</p>
 <h2>Remote branches</h2>
-<p>You should see a <strong>master</strong> branch (along with <strong><span class="caps">HEAD</span></strong>) in the history list.  But you will also have number of strangely named branches (<strong>origin/master</strong>, <strong>origin/greet</strong> and <strong>origin/<span class="caps">HEAD</span></strong>).  We&#8217;ll talk about them in a bit.</p>
+<p>You should see a <strong>main</strong> branch (along with <strong><span class="caps">HEAD</span></strong>) in the history list.  But you will also have number of strangely named branches (<strong>origin/main</strong>, <strong>origin/greet</strong> and <strong>origin/<span class="caps">HEAD</span></strong>).  We&#8217;ll talk about them in a bit.</p>
         <nav class="foot-navigation">
       <a href="lab_35.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_37.html
+++ b/docs/lab_37.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -112,14 +112,14 @@ origin
 * remote origin
   Fetch URL: /Users/opsparkowl/Documents/opspark/dev_shop/git-immersion/auto/hello
   Push  URL: /Users/opsparkowl/Documents/opspark/dev_shop/git-immersion/auto/hello
-  HEAD branch: master
+  HEAD branch: main
   Remote branches:
     greet  tracked
-    master tracked
+    main tracked
   Local branch configured for 'git pull':
-    master merges with remote master
+    main merges with remote main
   Local ref configured for 'git push':
-    master pushes to master (up to date)
+    main pushes to main (up to date)
 </pre>
 <p>Now we see that the remote repository &#8220;origin&#8221; is simply the original <strong>hello</strong> repository.  Remote repositories typically live on a separate machine, possibly a centralized server.  As we can see here, however, they can just as well point to a repository on the same machine. There is nothing particularly special about the name &#8220;origin&#8221;, however the convention is to use the name &#8220;origin&#8221; for the primary centralized repository (if there is one).</p>
         <nav class="foot-navigation">

--- a/docs/lab_38.html
+++ b/docs/lab_38.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -103,19 +103,19 @@
 <pre class="instructions">git branch</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git branch
-* master
+* main
 </pre>
-<p>That&#8217;s it, only the master branch is listed.  Where is the greet branch?  The <strong>git</strong> <strong>branch</strong> command only lists the local branches by default.</p>
+<p>That&#8217;s it, only the main branch is listed.  Where is the greet branch?  The <strong>git</strong> <strong>branch</strong> command only lists the local branches by default.</p>
 <h2>List Remote Branches</h2>
 <p>Try this to see all the branches:</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git branch -a</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git branch -a
-* master
-  remotes/origin/HEAD -&gt; origin/master
+* main
+  remotes/origin/HEAD -&gt; origin/main
   remotes/origin/greet
-  remotes/origin/master
+  remotes/origin/main
 </pre>
 <p>Git has all the commits from the original repository, but branches in the remote repository are not treated as local branches here.  If we want our own <strong>greet</strong> branch, we need to create it ourselves. We will see how to do that in a minute.</p>
         <nav class="foot-navigation">

--- a/docs/lab_39.html
+++ b/docs/lab_39.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_40.html
+++ b/docs/lab_40.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -106,10 +106,10 @@ git hist --all</pre>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git fetch
 From /Users/opsparkowl/Documents/opspark/dev_shop/git-immersion/auto/hello
-   c6d9ed3..21df587  master     -&gt; origin/master
+   c6d9ed3..21df587  main     -&gt; origin/main
 $ git hist --all
-* 21df587 2019-06-27 | Changed README in original repo (origin/master, origin/HEAD) [Halle Bot]
-* c6d9ed3 2019-06-27 | Updated package (HEAD -&gt; master, origin/greet) [Halle Bot]
+* 21df587 2019-06-27 | Changed README in original repo (origin/main, origin/HEAD) [Halle Bot]
+* c6d9ed3 2019-06-27 | Updated package (HEAD -&gt; main, origin/greet) [Halle Bot]
 * 56af19d 2019-06-27 | Hello uses Greeter [Halle Bot]
 * 1e7679d 2019-06-27 | Added greeter class [Halle Bot]
 * 3aa3064 2019-06-27 | Added README [Halle Bot]
@@ -121,8 +121,8 @@ $ git hist --all
 * 6915d41 2019-06-27 | Using process.argv [Halle Bot]
 * 284070d 2019-06-27 | First Commit [Halle Bot]</pre>
 <p>At this point the repository has all the commits from the original repository, but they are not integrated into the the cloned repository&#8217;s local branches.</p>
-<p>Find the &#8220;Changed <span class="caps">README</span> in original repo&#8221; commit in the history above.  Notice that the commit includes &#8220;origin/master&#8221; and &#8220;origin/<span class="caps">HEAD</span>&#8221;.</p>
-<p>Now look at the &#8220;Updated package.json&#8221; commit.  You will see that it the local master branch points to this commit, not to the new commit that we just fetched.</p>
+<p>Find the &#8220;Changed <span class="caps">README</span> in original repo&#8221; commit in the history above.  Notice that the commit includes &#8220;origin/main&#8221; and &#8220;origin/<span class="caps">HEAD</span>&#8221;.</p>
+<p>Now look at the &#8220;Updated package.json&#8221; commit.  You will see that it the local main branch points to this commit, not to the new commit that we just fetched.</p>
 <p>The upshot of this is that the &#8220;git fetch&#8221; command will fetch new commits from the remote repository, but it will not merge these commits into the local branches.</p>
 <h2>Check the <span class="caps">README</span></h2>
 <p>We can demonstrate that the cloned <span class="caps">README</span> is unchanged.</p>

--- a/docs/lab_41.html
+++ b/docs/lab_41.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -98,11 +98,11 @@
 <ul>
 	<li>Learn to get the pulled changes into the current branch and working directory.</li>
 </ul>
-<h2>Merge the fetched changes into local master</h2>
+<h2>Merge the fetched changes into local main</h2>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git merge origin/master</pre>
+<pre class="instructions">git merge origin/main</pre>
 <h3><b>Output:</b></h3>
-<pre class="sample">$ git merge origin/master
+<pre class="sample">$ git merge origin/main
 Updating c6d9ed3..21df587
 Fast-forward
  README | 1 +

--- a/docs/lab_42.html
+++ b/docs/lab_42.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -103,7 +103,7 @@
 <pre class="instructions">git pull</pre>
 <p>is indeed equivalent to the two steps:</p>
 <pre class="instructions">git fetch
-git merge origin/master</pre>
+git merge origin/main</pre>
         <nav class="foot-navigation">
       <a href="lab_41.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_43.html
+++ b/docs/lab_43.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -109,12 +109,12 @@ git hist --max-count=2</pre>
 Branch 'greet' set up to track remote branch 'greet' from 'origin'.
 $ git branch -a
   greet
-* master
-  remotes/origin/HEAD -&gt; origin/master
+* main
+  remotes/origin/HEAD -&gt; origin/main
   remotes/origin/greet
-  remotes/origin/master
+  remotes/origin/main
 $ git hist --max-count=2
-* 21df587 2019-06-27 | Changed README in original repo (HEAD -&gt; master, origin/master, origin/HEAD) [Halle Bot]
+* 21df587 2019-06-27 | Changed README in original repo (HEAD -&gt; main, origin/main, origin/HEAD) [Halle Bot]
 * c6d9ed3 2019-06-27 | Updated package (origin/greet, greet) [Halle Bot]</pre>
 <p>We can now see the greet branch in the branch list and in the log.</p>
         <nav class="foot-navigation">

--- a/docs/lab_44.html
+++ b/docs/lab_44.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_45.html
+++ b/docs/lab_45.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_46.html
+++ b/docs/lab_46.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -105,19 +105,19 @@
 (Changed in the original and pushed to shared)
 </pre>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git checkout master
+<pre class="instructions">git checkout main
 git add README
 git commit -m "Added shared comment to readme"</pre>
 <p>Now push the change to the shared repo.</p>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git push shared master</pre>
+<pre class="instructions">git push shared main</pre>
 <p><em>shared</em> is the name of the repository receiving the changes we are pushing. (Remember, we added it as a remote in the previous lab.)</p>
 <h3><b>Output:</b></h3>
-<pre class="sample">$ git push shared master
+<pre class="sample">$ git push shared main
 To ../hello.git
-   21df587..4f590f6  master -&gt; master
+   21df587..4f590f6  main -&gt; main
 </pre>
-<p class="note"><strong><span class="caps">NOTE</span>:</strong> We had to explicitly name the branch master that was receiving the push.  It is possible to set it up automatically, but I <em>never</em> remember the commands to do that.  Check out the &#8220;Git Remote Branch&#8221; gem for easy management of remote branches.</p>
+<p class="note"><strong><span class="caps">NOTE</span>:</strong> We had to explicitly name the branch main that was receiving the push.  It is possible to set it up automatically, but I <em>never</em> remember the commands to do that.  Check out the &#8220;Git Remote Branch&#8221; gem for easy management of remote branches.</p>
         <nav class="foot-navigation">
       <a href="lab_45.html">
       <svg version="1.1" width="36" height="36" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M27.66,15.61,18,6,8.34,15.61A1,1,0,1,0,9.75,17L17,9.81V28.94a1,1,0,1,0,2,0V9.81L26.25,17a1,1,0,0,0,1.41-1.42Z"></path></svg>

--- a/docs/lab_47.html
+++ b/docs/lab_47.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>
@@ -105,8 +105,8 @@
 <p>Continue with&#8230;</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git remote add shared ../hello.git
-git branch --track shared master
-git pull shared master
+git branch --track shared main
+git pull shared main
 cat README</pre>
         <nav class="foot-navigation">
       <a href="lab_46.html">

--- a/docs/lab_48.html
+++ b/docs/lab_48.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_49.html
+++ b/docs/lab_49.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_50.html
+++ b/docs/lab_50.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/docs/lab_51.html
+++ b/docs/lab_51.html
@@ -59,16 +59,16 @@
   <li id="lab_21_link"><a href="lab_21.html">More Structure</a></li>
   <li id="lab_22_link"><a href="lab_22.html">Creating a Branch</a></li>
   <li id="lab_23_link"><a href="lab_23.html">Navigating Branches</a></li>
-  <li id="lab_24_link"><a href="lab_24.html">Changes in Master</a></li>
+  <li id="lab_24_link"><a href="lab_24.html">Changes in Main</a></li>
   <li id="lab_25_link"><a href="lab_25.html">Viewing Diverging Branches</a></li>
   <li id="lab_26_link"><a href="lab_26.html">Merging</a></li>
   <li id="lab_27_link"><a href="lab_27.html">Creating a Conflict</a></li>
   <li id="lab_28_link"><a href="lab_28.html">Resolving Conflicts</a></li>
   <li id="lab_29_link"><a href="lab_29.html">Rebasing VS Merging</a></li>
   <li id="lab_30_link"><a href="lab_30.html">Resetting the Greet Branch</a></li>
-  <li id="lab_31_link"><a href="lab_31.html">Resetting the Master Branch</a></li>
+  <li id="lab_31_link"><a href="lab_31.html">Resetting the Main Branch</a></li>
   <li id="lab_32_link"><a href="lab_32.html">Rebasing</a></li>
-  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Master</a></li>
+  <li id="lab_33_link"><a href="lab_33.html">Merging Back to Main</a></li>
   <li id="lab_34_link"><a href="lab_34.html">Multiple Repositories</a></li>
   <li id="lab_35_link"><a href="lab_35.html">Cloning Repositories</a></li>
   <li id="lab_36_link"><a href="lab_36.html">Review the Cloned Repository</a></li>

--- a/src/index.html
+++ b/src/index.html
@@ -114,16 +114,16 @@
         <li id="lab_23_link" data-lab-id="23"><a href="lab_23.html"><span>23:</span> Git Internals: Working directly with Git Objects</a></li>
         <li id="lab_24_link" data-lab-id="24"><a href="lab_24.html"><span>24:</span> Creating a Branch</a></li>
         <li id="lab_25_link" data-lab-id="25"><a href="lab_25.html"><span>25:</span> Navigating Branches</a></li>
-        <li id="lab_26_link" data-lab-id="26"><a href="lab_26.html"><span>26:</span> Changes in Master</a></li>
+        <li id="lab_26_link" data-lab-id="26"><a href="lab_26.html"><span>26:</span> Changes in Main</a></li>
         <li id="lab_27_link" data-lab-id="27"><a href="lab_27.html"><span>27:</span> Viewing Diverging Branches</a></li>
         <li id="lab_28_link" data-lab-id="28"><a href="lab_28.html"><span>28:</span> Merging</a></li>
         <li id="lab_29_link" data-lab-id="29"><a href="lab_29.html"><span>29:</span> Creating a Conflict</a></li>
         <li id="lab_30_link" data-lab-id="30"><a href="lab_30.html"><span>30:</span> Resolving Conflicts</a></li>
         <li id="lab_31_link" data-lab-id="31"><a href="lab_31.html"><span>31:</span> Rebasing VS Merging</a></li>
         <li id="lab_32_link" data-lab-id="32"><a href="lab_32.html"><span>32:</span> Resetting the Greet Branch</a></li>
-        <li id="lab_33_link" data-lab-id="33"><a href="lab_33.html"><span>33:</span> Resetting the Master Branch</a></li>
+        <li id="lab_33_link" data-lab-id="33"><a href="lab_33.html"><span>33:</span> Resetting the Main Branch</a></li>
         <li id="lab_34_link" data-lab-id="34"><a href="lab_34.html"><span>34:</span> Rebasing</a></li>
-        <li id="lab_35_link" data-lab-id="35"><a href="lab_35.html"><span>35:</span> Merging Back to Master</a></li>
+        <li id="lab_35_link" data-lab-id="35"><a href="lab_35.html"><span>35:</span> Merging Back to Main</a></li>
         <li id="lab_36_link" data-lab-id="36"><a href="lab_36.html"><span>36:</span> Multiple Repositories</a></li>
         <li id="lab_37_link" data-lab-id="37"><a href="lab_37.html"><span>37:</span> Cloning Repositories</a></li>
         <li id="lab_38_link" data-lab-id="38"><a href="lab_38.html"><span>38:</span> Review the Cloned Repository</a></li>

--- a/src/lab_01.html
+++ b/src/lab_01.html
@@ -86,16 +86,16 @@
         <li id="lab_23_link"><a href="lab_23.html"><span>23:</span> Git Internals: Working directly with Git Objects</a></li>
         <li id="lab_24_link"><a href="lab_24.html"><span>24:</span> Creating a Branch</a></li>
         <li id="lab_25_link"><a href="lab_25.html"><span>25:</span> Navigating Branches</a></li>
-        <li id="lab_26_link"><a href="lab_26.html"><span>26:</span> Changes in Master</a></li>
+        <li id="lab_26_link"><a href="lab_26.html"><span>26:</span> Changes in Main</a></li>
         <li id="lab_27_link"><a href="lab_27.html"><span>27:</span> Viewing Diverging Branches</a></li>
         <li id="lab_28_link"><a href="lab_28.html"><span>28:</span> Merging</a></li>
         <li id="lab_29_link"><a href="lab_29.html"><span>29:</span> Creating a Conflict</a></li>
         <li id="lab_30_link"><a href="lab_30.html"><span>30:</span> Resolving Conflicts</a></li>
         <li id="lab_31_link"><a href="lab_31.html"><span>31:</span> Rebasing VS Merging</a></li>
         <li id="lab_32_link"><a href="lab_32.html"><span>32:</span> Resetting the Greet Branch</a></li>
-        <li id="lab_33_link"><a href="lab_33.html"><span>33:</span> Resetting the Master Branch</a></li>
+        <li id="lab_33_link"><a href="lab_33.html"><span>33:</span> Resetting the Main Branch</a></li>
         <li id="lab_34_link"><a href="lab_34.html"><span>34:</span> Rebasing</a></li>
-        <li id="lab_35_link"><a href="lab_35.html"><span>35:</span> Merging Back to Master</a></li>
+        <li id="lab_35_link"><a href="lab_35.html"><span>35:</span> Merging Back to Main</a></li>
         <li id="lab_36_link"><a href="lab_36.html"><span>36:</span> Multiple Repositories</a></li>
         <li id="lab_37_link"><a href="lab_37.html"><span>37:</span> Cloning Repositories</a></li>
         <li id="lab_38_link"><a href="lab_38.html"><span>38:</span> Review the Cloned Repository</a></li>

--- a/src/labs.txt
+++ b/src/labs.txt
@@ -286,7 +286,7 @@ Output:
 |
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
-# On branch master
+# On branch main
 # Changes to be committed:
 #   (use "git reset HEAD <file>..." to unstage)
 #
@@ -300,7 +300,7 @@ and exit the editor.  You should see ...
 Output:
 git commit
 Waiting for Vim...
-[master 569aa96] Using process.argv
+[main 569aa96] Using process.argv
  1 files changed, 1 insertions(+), 1 deletions(-)
 EOF
 
@@ -681,10 +681,10 @@ branch.  In any case, don't worry about that for now.
 
 p. Notice the contents of the hello.js file are the original contents.
 
-h2. Return the latest version in the master branch
+h2. Return the latest version in the main branch
 
 Execute:
-git checkout master
+git checkout main
 =checkout2
 cat hello.js
 =cat2
@@ -696,7 +696,7 @@ Output:
 =cat2
 EOF
 
-p. 'master' is the name of the default branch.  By checking out a branch
+p. 'main' is the name of the default branch.  By checking out a branch
 by name, you go to the latest version of that branch.
 
 ----------------------------------------------------------------------
@@ -776,7 +776,7 @@ h2. Viewing Tags in the Logs
 p. You can also check for tags in the log.
 
 Execute:
-git hist master --all
+git hist main --all
 =hist
 
 Output:
@@ -784,7 +784,7 @@ Output:
 EOF
 
 p. You can see both tags (@v1@ and @v1-beta@) listed in the log
-output, along with the branch name (@master@).  Also @HEAD@ shows you
+output, along with the branch name (@main@).  Also @HEAD@ shows you
 the currently checked out commit (which is @v1-beta@ at the moment).
 
 ----------------------------------------------------------------------
@@ -794,12 +794,12 @@ h2. Goals
 
 * Learn how to revert changes in the working directory
 
-h2. Checkout Master
+h2. Checkout Main
 
-p. Make sure you are on the latest commit in master before proceeding.
+p. Make sure you are on the latest commit in main before proceeding.
 
 Execute:
-git checkout master
+git checkout main
 
 h2. Change hello.js
 
@@ -1079,7 +1079,7 @@ Output:
 =hist2
 EOF
 
-p. Our master branch now points to the v1 commit and the Oops commit
+p. Our main branch now points to the v1 commit and the Oops commit
 and the Revert Oops commit are no longer in the branch.  The @--hard@
 parameter indicates that the working directory should be updated to be
 consistent with the new branch head.
@@ -1101,7 +1101,7 @@ EOF
 
 p. Here we see that the bad commits haven't disappeared.  They are
 still in the repository.  It's just that they are no longer listed in
-the master branch.  If we hadn't tagged them, they would still be in
+the main branch.  If we hadn't tagged them, they would still be in
 the repository, but there would be no way to reference them other than
 using their hash names.  Commits that are unreferenced remain in the
 repository until the system runs the garbage collection software.
@@ -1319,7 +1319,7 @@ h2. Goals
 
 p. It's time to do a major rewrite of the hello world functionality.
 Since this might take awhile, you'll want to put these changes into a
-separate branch to isolate them from changes in master.
+separate branch to isolate them from changes in main.
 
 h2. Create a Branch
 
@@ -1414,12 +1414,12 @@ Output:
 =log
 EOF
 
-h2. Switch to the Master Branch
+h2. Switch to the Main Branch
 
 p. Just use the @git checkout@ command to switch between branches.
 
 Execute:
-git checkout master
+git checkout main
 =checkout
 cat lib/hello.js
 =cat
@@ -1429,7 +1429,7 @@ Output:
 =cat
 EOF
 
-p. You are now on the master branch.  You can tell because the
+p. You are now on the main branch.  You can tell because the
 hello.js file doesn't use the @Greeter@ class.
 
 h2. Switch Back to the Greet Branch.
@@ -1449,19 +1449,19 @@ p. The contents of the @lib/hello.js@ confirms we are back on the
 *greet* branch.
 
 ----------------------------------------------------------------------
-h1. Changes in Master
+h1. Changes in Main
 
 h2. Goals
 
 * Learning how to deal with multiple branches with different (and possibly conflicting) changes.
 
 p. While you were changing the greet branch, someone else decided to
-update the master branch.  They added a README.
+update the main branch.  They added a README.
 
-h2. Switch to the master branch.
+h2. Switch to the main branch.
 
 Execute:
-git checkout master
+git checkout main
 
 h2. Create the README.
 
@@ -1469,7 +1469,7 @@ File: README
 This is the Hello World example from the git tutorial.
 EOF
 
-h2. Commit the README to master.
+h2. Commit the README to main.
 
 Execute:
 git add README
@@ -1498,7 +1498,7 @@ EOF
 p. Here is our first chance to see the @--graph@ option on @git hist@ in
 action. Adding the @--graph@ option to @git log@ causes it to draw the
 commit tree using simple ASCII characters.  We can see both branches
-(greet and master), and that the master branch is the current HEAD.
+(greet and main), and that the main branch is the current HEAD.
 The common ancestor to both branches is the "Added a Rakefile" branch.
 
 p. The @--all@ flag makes sure that we see all the branches.  The
@@ -1514,12 +1514,12 @@ h2. Goals
 h2. Merge the branches
 
 p. Merging brings the changes in two branches together.  Let's go back
-to the greet branch and merge master onto greet.
+to the greet branch and merge main onto greet.
 
 Execute:
 git checkout greet
 =checkout
-git merge master
+git merge main
 =merge
 git hist --all
 =hist
@@ -1530,8 +1530,8 @@ Output:
 =hist
 EOF
 
-p. By merging master into your greet branch periodically, you can pick
-up any changes to master and keep your changes in greet compatible
+p. By merging main into your greet branch periodically, you can pick
+up any changes to main and keep your changes in greet compatible
 with changes in the mainline.
 
 p. However, it does produce ugly commit graphs. Later we will look at
@@ -1539,7 +1539,7 @@ the option of rebasing rather than merging.
 
 h2. Up Next
 
-p. But first, what if the changes in master conflict with the changes
+p. But first, what if the changes in main conflict with the changes
 in greet?
 
 ----------------------------------------------------------------------
@@ -1547,14 +1547,14 @@ h1. Creating a Conflict
 
 h2. Goals
 
-* Create a conflicting change in the master branch.
+* Create a conflicting change in the main branch.
 
-h2. Switch back to master and create a conflict
+h2. Switch back to main and create a conflict
 
-p. Switch back to the master branch and make this change:
+p. Switch back to the main branch and make this change:
 
 Execute:
-git checkout master
+git checkout main
 
 File: lib/hello.js
 const rl = require('readline').createInterface({
@@ -1582,13 +1582,13 @@ Output:
 =log
 EOF
 
-p. Master at commit "Added README" has been merged to the greet
-branch, but there is now an additional commit on master that has not
+p. Main at commit "Added README" has been merged to the greet
+branch, but there is now an additional commit on main that has not
 been merged back to greet.
 
 h2. Up Next
 
-p. The latest change in master conflicts with some existing changes in
+p. The latest change in main conflicts with some existing changes in
 greet.  Next we will resolve those changes.
 
 ----------------------------------------------------------------------
@@ -1598,18 +1598,18 @@ h2. Goals
 
 * Learn how to handle conflicts during a merge
 
-h2. Merge master to greet
+h2. Merge main to greet
 
-p. Now go back to the greet branch and try to merge the new master.
+p. Now go back to the greet branch and try to merge the new main.
 
 Execute:
 git checkout greet
-!git merge master
+!git merge main
 
 Output:
 $ git checkout greet
 Switched to branch 'greet'
-$ git merge master
+$ git merge main
 Auto-merging lib/hello.js
 CONFLICT (content): Merge conflict in lib/hello.js
 Automatic merge failed; fix conflicts and then commit the result.
@@ -1638,11 +1638,11 @@ rl.question(`What's your name`, (myName) => {
   console.log(`Hello ${myName}!`)
   rl.close();
 });
->>>>>>> master
+>>>>>>> main
 EOF
 <!-- ^^^^^^^^^  DO NOT FIX THIS MERGE CONFLICT ^^^^^^^^^ -->
 p. The first section is the version on the head of the current branch
-(greet).  The second section is the version on the master branch.
+(greet).  The second section is the version on the main branch.
 
 h2. Fix the Conflict
 
@@ -1670,7 +1670,7 @@ h2. Commit the Conflict Resolution
 Execute:
 git add lib/hello.js
 =add
-git commit -m "Merged master fixed conflict."
+git commit -m "Merged main fixed conflict."
 =commit
 
 Output:
@@ -1712,12 +1712,12 @@ h2. Goals
 h2. Reset the greet branch
 
 p. Let's go back in time on the greet branch to the point _before_ we
-merged master onto it.  We can *reset* a branch to any commit we want.
+merged main onto it.  We can *reset* a branch to any commit we want.
 Essentially this is modifying the branch pointer to point to anywhere
 in the commit tree.
 
 p. In this case we want to back greet up to the point prior to the
-merge with master.  We need to find the last commit before the merge.
+merge with main.  We need to find the last commit before the merge.
 
 Execute:
 git checkout greet
@@ -1757,22 +1757,22 @@ Output:
 EOF
 
 ----------------------------------------------------------------------
-h1. Resetting the Master Branch
+h1. Resetting the Main Branch
 
 h2. Goals
 
-* Reset the master branch to the point before the conflicting commit.
+* Reset the main branch to the point before the conflicting commit.
 
-h2. Reset the master branch
+h2. Reset the main branch
 
-p. When we added the interactive mode to the master branch, we made a
+p. When we added the interactive mode to the main branch, we made a
 change that conflicted with changes in the greet branch. Let's rewind
-the master branch to a point before the conflicting change.  This
+the main branch to a point before the conflicting change.  This
 allows us to demonstrate the rebase command without worrying about
 conflicts.
 
 Execute:
-git checkout master
+git checkout main
 git hist
 =log
 
@@ -1781,7 +1781,7 @@ Output:
 EOF
 
 p. The 'Added README' commit is the one directly before the
-conflicting interactive mode.  We will reset the master branch to
+conflicting interactive mode.  We will reset the main branch to
 'Added README' branch.
 
 Set: hash=hash_for("Added README")
@@ -1805,14 +1805,14 @@ h2. Goals
 * Use the rebase command rather than the merge command.
 
 p. Ok, we are back in time before the first merge and we want to get
-the changes in master into our greet branch.
+the changes in main into our greet branch.
 
 p. This time we will use the rebase command instead of the merge
-command to bring in the changes from the master branch.
+command to bring in the changes from the main branch.
 
 Execute:
 git checkout greet
-git rebase master
+git rebase main
 git hist
 =log
 
@@ -1820,7 +1820,7 @@ Output:
 $ go greet
 Switched to branch 'greet'
 $
-$ git rebase master
+$ git rebase main
 First, rewinding head to replay your work on top of it...
 Applying: added Greeter class
 Applying: hello uses Greeter
@@ -1833,9 +1833,9 @@ h2. Merge VS Rebase
 
 p. The final result of the rebase is very similar to the merge.  The
 greet branch now contains all of its changes, as well as all the
-changes from the master branch.  However, the commit tree is quite
+changes from the main branch.  However, the commit tree is quite
 different.  The commit tree for the greet branch has been rewritten so
-that the master branch is a part of the commit history.  This leaves
+that the main branch is a part of the commit history.  This leaves
 the chain of commits linear and much easier to read.
 
 h2. When to Rebase, When to Merge?
@@ -1849,27 +1849,27 @@ p. Given the above guidelines, I tend to use rebase for short-lived,
 local branches and merge for branches in the public repository.
 
 ----------------------------------------------------------------------
-h1. Merging Back to Master
+h1. Merging Back to Main
 
 h2. Goals
 
-* We've kept our greet branch up to date with master (via rebase), now let's merge the greet changes back into the master branch.
+* We've kept our greet branch up to date with main (via rebase), now let's merge the greet changes back into the main branch.
 
-h2. Merge greet into master
+h2. Merge greet into main
 
 Execute:
-git checkout master
+git checkout main
 git merge greet
 =merge
 
 Output:
-$ git checkout master
-Switched to branch 'master'
+$ git checkout main
+Switched to branch 'main'
 $
 =merge
 EOF
 
-p. Because the head of master is a direct ancestor of the head of the
+p. Because the head of main is a direct ancestor of the head of the
 greet branch, git is able to do a fast-forward merge.  When
 fast-forwarding, the branch pointer is simply moved forward to point
 to the same commit as the greeter branch.
@@ -1886,7 +1886,7 @@ Output:
 =log
 EOF
 
-p. The greet and master branches are now identical.
+p. The greet and main branches are now identical.
 
 ----------------------------------------------------------------------
 h1. Multiple Repositories
@@ -2010,9 +2010,9 @@ names of the branches.
 
 h2. Remote branches
 
-p. You should see a *master* branch (along with *HEAD*) in the history
+p. You should see a *main* branch (along with *HEAD*) in the history
 list.  But you will also have number of strangely named branches
-(*origin/master*, *origin/greet* and *origin/HEAD*).  We'll talk about
+(*origin/main*, *origin/greet* and *origin/HEAD*).  We'll talk about
 them in a bit.
 
 ----------------------------------------------------------------------
@@ -2066,7 +2066,7 @@ Output:
 =branch
 EOF
 
-p. That's it, only the master branch is listed.  Where is the greet
+p. That's it, only the main branch is listed.  Where is the greet
 branch?  The *git* *branch* command only lists the local branches by
 default.
 
@@ -2149,11 +2149,11 @@ repository, but they are not integrated into the the cloned
 repository's local branches.
 
 p. Find the "Changed README in original repo" commit in the history
-above.  Notice that the commit includes "origin/master" and
+above.  Notice that the commit includes "origin/main" and
 "origin/HEAD".
 
 p. Now look at the "Updated package.json" commit.  You will see that it
-the local master branch points to this commit, not to the new commit
+the local main branch points to this commit, not to the new commit
 that we just fetched.
 
 p. The upshot of this is that the "git fetch" command will fetch new
@@ -2181,10 +2181,10 @@ h2. Goals
 
 * Learn to get the pulled changes into the current branch and working directory.
 
-h2. Merge the fetched changes into local master
+h2. Merge the fetched changes into local main
 
 Execute:
-git merge origin/master
+git merge origin/main
 =merge
 
 Output:
@@ -2230,7 +2230,7 @@ pre(instructions). git pull
 is indeed equivalent to the two steps:
 
 pre(instructions). git fetch
-git merge origin/master
+git merge origin/main
 
 ----------------------------------------------------------------------
 h1. Adding a Tracking Branch
@@ -2329,14 +2329,14 @@ This is the Hello World example from the git tutorial.
 EOF
 
 Execute:
-git checkout master
+git checkout main
 git add README
 git commit -m "Added shared comment to readme"
 
 p. Now push the change to the shared repo.
 
 Execute:
-git push shared master
+git push shared main
 =push
 
 p. _shared_ is the name of the repository receiving the changes we are
@@ -2346,7 +2346,7 @@ Output:
 =push
 EOF
 
-p(note). *NOTE:* We had to explicitly name the branch master that was
+p(note). *NOTE:* We had to explicitly name the branch main that was
 receiving the push.  It is possible to set it up automatically, but I
 _never_ remember the commands to do that.  Check out the "Git Remote
 Branch" gem for easy management of remote branches.
@@ -2371,8 +2371,8 @@ p. Continue with...
 
 Execute:
 git remote add shared ../hello.git
-git branch --track shared master
-git pull shared master
+git branch --track shared main
+git pull shared main
 cat README
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Update the instructions to:

- Updated branch name used from master to main
- remove the vim part because the simulator only allows a commit with -m