### PR TITLE
Add start.js file to git immersion instructions

### DIFF
--- a/docs/lab_03.html
+++ b/docs/lab_03.html
@@ -99,12 +99,17 @@
 	<li>Learn how to create a git repository from scratch.</li>
 </ul>
 <h2>Create a &#8220;Hello, World&#8221; program</h2>
-<p>Starting in the empty working directory, create an empty directory named &#8220;hello&#8221;, then create a file named <code>hello.js</code> with the contents below.</p>
+<p>Starting in the empty working directory, create an empty directory named &#8220;hello&#8221;, then create two files named <code>hello.js</code> and <code>start.js</code> with the contents below.</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">mkdir hello
 cd hello</pre>
 <h3 class="file-heading"><em>hello.js</em></h3>
 <pre class="file">console.log("Hello, World");
+</pre>
+<h3 class="file-heading"><em>start.js</em></h3>
+<pre class="file">const { sayHello } = require('./hello');
+
+  sayHello();
 </pre>
 <h2>Create the Repository</h2>
 <p>You now have a directory with a single file.  To create a git repository from that directory, run the git init command.</p>
@@ -118,14 +123,17 @@ Initialized empty Git repository in /Users/opsparkowl/Documents/opspark/dev_shop
 <p>Now let&#8217;s add the &#8220;Hello, World&#8221; program to the repository.</p>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git add hello.js
+git add start.js
 git commit -m "First Commit"</pre>
 <p>You should see &#8230;</p>
 <h3><b>Output:</b></h3>
 <pre class="sample">$ git add hello.js
+$ git add start.js
 $ git commit -m "First Commit"
 [main (root-commit) 284070d] First Commit
- 1 file changed, 1 insertion(+)
+ 2 files changed, 2 insertion(+)
  create mode 100644 hello.js
+ create mode 100644 start.js
 </pre>
         <nav class="foot-navigation">
       <a href="lab_02.html">

--- a/docs/lab_08.html
+++ b/docs/lab_08.html
@@ -103,7 +103,7 @@
 <p>Committing is the action of saving the changes to the repository.  It is like taking a snapshot of the changes.  You can always go back to this snapshot later.</p>
 <p>So commit now and check the status.</p>
 <h3><b>Execute:</b></h3>
-<pre class="instructions">git commit -m "Using process.argv</pre>
+<pre class="instructions">git commit -m "Using process.argv"</pre>
 <pre class="instructions">git status</pre>
 </pre>
 <p>You should see &#8230;</p>

--- a/docs/lab_08.html
+++ b/docs/lab_08.html
@@ -98,10 +98,40 @@
 <ul>
 	<li>Learn how to commit changes to the repository</li>
 </ul>
-<h2>Commit the change</h2>
+
+<h2>Committing u using an editor</h2>
 <p>Ok, enough about staging.  Let&#8217;s commit what we have staged to the repository.</p>
+<p>When you used <code>git commit</code> previously to commit the initial version of the <code>hello.js</code> file to the repository, you included the <code>-m</code> flag that gave a comment on the command line.  The commit command will allow you to interactively edit a comment for the commit.</p>
+<p>If you omit the <code>-m</code> flag from the command line, git will pop you into the editor of your choice.  The editor is chosen from the following list (in priority order):</p>
+<ul>
+  <li>GIT_EDITOR environment variable</li>
+	<li>core.editor configuration setting</li>
+	<li><span class="caps">VISUAL</span> environment variable</li>
+	<li><span class="caps">EDITOR</span> environment variable</li>
+</ul>
+<p>I have the <span class="caps">EDITOR</span> variable set to <code>vim</code>. Here's an example of what that would look like:</p>
+<pre class="sample">|
+  # Please enter the commit message for your changes. Lines starting
+  # with '#' will be ignored, and an empty message aborts the commit.
+  # On branch master
+  # Changes to be committed:
+  #   (use "git reset HEAD &lt;file&gt;..." to unstage)
+  #
+  #	modified:   hello.js
+  #
+</pre>
+<p>On the first line, you would enter the commit message for example: &#8220;Using process.argv&#8221;.  Save the file and exit the editor.  You then would see:</p>
+<pre class="sample">git commit
+  Waiting for Vim...
+  [master 569aa96] Using process.argv
+  1 files changed, 1 insertions(+), 1 deletions(-)
+</pre>
+<p>The &#8220;Waiting for Vim&#8230;&#8221; line comes from the <code>vim</code> program which sends the file to a running vim program and waits for the file to be closed.  The rest of the output is the standard commit messages.</p>
 <p>Committing is the action of saving the changes to the repository.  It is like taking a snapshot of the changes.  You can always go back to this snapshot later.</p>
-<p>So commit now and check the status.</p>
+
+<h2>Commit the change</h2>
+<p> For this assignment we will use the <code>-m</code> flag so that you can commit in the simulation terminal. So commit now and check the status.</p>
+
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git commit -m "Using process.argv"</pre>
 <pre class="instructions">git status</pre>

--- a/docs/lab_21.html
+++ b/docs/lab_21.html
@@ -107,7 +107,7 @@
   "version": "1.0.0",
   "description": "Greet users from the command line",
   "scripts": {
-    "start": "node lib/hello.js"
+    "start": "node lib/start.js"
   }
 }
 </pre>
@@ -125,7 +125,7 @@ git commit -m "Added a package.json."</pre>
 <pre class="sample">$ npm start
 
 &gt; greeter@1.0.0 start /Users/opsparkowl/Documents/opspark/dev_shop/git-immersion/auto/hello
-&gt; node lib/hello.js
+&gt; node lib/start.js
 
 Hello, World!
 </pre>

--- a/docs/lab_22.html
+++ b/docs/lab_22.html
@@ -145,7 +145,7 @@ git commit -m "Hello uses Greeter"</pre>
   "version": "1.0.0",
   "description": "Greet users from the command line",
   "scripts": {
-    "start": "node lib/hello.js 'Halle Bot'"
+    "start": "node lib/start.js 'Halle Bot'"
   }
 }
 </pre>

--- a/docs/lab_27.html
+++ b/docs/lab_27.html
@@ -105,13 +105,14 @@
 <h3 class="file-heading"><em>lib/hello.js</em></h3>
 <pre class="file">const rl = require('readline').createInterface({
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
 });
 
-rl.question(`What's your name`, (myName) =&gt; {
-  console.log(`Hello ${myName}!`)
-  rl.close();
-});
+module.exports.sayHello = () => {
+  rl.question(`What's your name? `, (name) => {
+    console.log(`Hello ${name}!`);
+  });
+};
 </pre>
 <h3><b>Execute:</b></h3>
 <pre class="instructions">git add lib/hello.js

--- a/docs/lab_28.html
+++ b/docs/lab_28.html
@@ -125,13 +125,14 @@ console.log(greeter.greet());
 =======
 const rl = require('readline').createInterface({
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
 });
 
-rl.question(`What's your name`, (myName) =&gt; {
-  console.log(`Hello ${myName}!`)
-  rl.close();
-});
+module.exports.sayHello = () => {
+  rl.question(`What's your name? `, (name) => {
+    console.log(`Hello ${name}!`);
+  });
+};
 &gt;&gt;&gt;&gt;&gt;&gt;&gt; main
 </pre>
 <p><!-- ^^^^^^^^^  DO NOT FIX THIS MERGE CONFLICT ^^^^^^^^^ --><br />

--- a/src/labs.txt
+++ b/src/labs.txt
@@ -1289,7 +1289,7 @@ File: package.json
   "version": "1.0.0",
   "description": "Greet users from the command line",
   "scripts": {
-    "start": "node lib/hello.js"
+    "start": "node lib/start.js"
   }
 }
 EOF
@@ -1383,7 +1383,7 @@ File: package.json
   "version": "1.0.0",
   "description": "Greet users from the command line",
   "scripts": {
-    "start": "node lib/hello.js 'Halle Bot'"
+    "start": "node lib/start.js 'Halle Bot'"
   }
 }
 EOF


### PR DESCRIPTION
Currently the instructions are not using the start.js file that is being added in the [course.git-immersion](https://github.com/OperationSpark/course.git-immersion/pulls) repo.

-Made changes to the required package.json file to use start.js
-Added the creation of the start.js file to the instructions